### PR TITLE
Add arm64 macOS qiosurfacegraphicsbuffer patch

### DIFF
--- a/overlay/osx/qt5-base/patches/arm64_qiosurfacegraphicsbuffer.patch
+++ b/overlay/osx/qt5-base/patches/arm64_qiosurfacegraphicsbuffer.patch
@@ -1,0 +1,12 @@
+--- a/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
++++ b/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+@@ -43,6 +43,9 @@
+ #include <qpa/qplatformgraphicsbuffer.h>
+ #include <private/qcore_mac_p.h>
+ 
++#include <CoreGraphics/CGColorSpace.h>
++#include <IOSurface/IOSurface.h>
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QIOSurfaceGraphicsBuffer : public QPlatformGraphicsBuffer

--- a/overlay/osx/qt5-base/portfile.cmake
+++ b/overlay/osx/qt5-base/portfile.cmake
@@ -31,7 +31,8 @@ qt_download_submodule(  OUT_SOURCE_PATH SOURCE_PATH
                             #patches/static_opengl.patch #Use this patch if you really want to statically link angle on windows (e.g. using -opengl es2 and -static). 
                                                          #Be carefull since it requires definining _GDI32_ for all dependent projects due to redefinition errors in the 
                                                          #the windows supplied gl.h header and the angle gl.h otherwise. 
-                            patches/arm64_qcocoahelper.patch   # alow to build on arm64 
+                            patches/arm64_qiosurfacegraphicsbuffer.patch   # allow to build on arm64
+                            patches/arm64_qcocoahelper.patch   # allow to build on arm64
                             patches/arm64_send_super_stret.patch     # don't use qt_msgSendSuper_stret on arm64 
                     )
 


### PR DESCRIPTION
Fixes the Qt5 build on ARM64 Macs by patching in a `CoreGraphics` header that was previously included transitively.